### PR TITLE
Version 1.0.2 - Importar modulos desde el __init__.py

### DIFF
--- a/manucr19_py/__init__.py
+++ b/manucr19_py/__init__.py
@@ -1,0 +1,2 @@
+import tui
+import file

--- a/manucr19_py/__init__.py
+++ b/manucr19_py/__init__.py
@@ -1,2 +1,2 @@
-import tui
-import file
+from . import tui
+from . import file

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='manucr19_py',
-    version='1.0.1',
+    version='1.0.2',
     url='https://github.com/manucr19/library',
     packages=find_packages(),
     license='GPLv3',


### PR DESCRIPTION
Este cambio permite importar el paquete como:

`import manucr19_py`

Y posteriormente utilizar las funciones de la siguiente manera:

`manucr19_py.tui.infobox("title","text")`